### PR TITLE
feat: logical CPU num as default threads num

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use {
 	},
 	argh::FromArgs,
 	hex::ToHex,
-	num_cpus::get_physical,
+	num_cpus::get,
 	anyhow::{Context, Result},
 };
 
@@ -22,7 +22,7 @@ use {
 /// Generate Good-looking GPG Keys
 struct CliArgs {
 	/// number of threads to use, defaults to number of physical CPU cores
-	#[argh(option, default = "get_physical()")]
+	#[argh(option, default = "get()")]
 	threads: usize,
 	/// max backflow of one iteration, in seconds, defaults to 30 days equivalent
 	#[argh(option, default = "86400 * 30")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use {
 #[derive(FromArgs)]
 /// Generate Good-looking GPG Keys
 struct CliArgs {
-	/// number of threads to use, defaults to number of physical CPU cores
+	/// number of threads to use, defaults to number of logical CPU cores
 	#[argh(option, default = "get()")]
 	threads: usize,
 	/// max backflow of one iteration, in seconds, defaults to 30 days equivalent


### PR DESCRIPTION
A CPU may have 8 physical cores but 16 logical, that can lead to underutilization.

Please squash my PR if you want to merge to `master`, there are only minor diff.